### PR TITLE
Correctly convert nested lists

### DIFF
--- a/samples/Jsonix/Features.md
+++ b/samples/Jsonix/Features.md
@@ -1,34 +1,29 @@
+
+
 # Features
 
 * Runs in almost **any** modern **browser**
 * Runs in [node.js](http://nodejs.org/)
 * Implements **marshalling** (serializing a JavaScript object info XML)
 	
+
   * Supports **string** data and **DOM** nodes as result
-
-
 * Implements **unmarshalling** (parsing a JavaScript object from XML)
 	
+
   * Supports **string** data, **DOM** nodes, **URLs** or **files** (with node.js) as source
-
-
 * Driven by **declarative** XML/object **mappings** which control how JavaScript object is converted into XML or vice versa
 * **Mappings** can be **automatically generated** based on an **XML Schema**
-* **Strongly-structured**  * XML/object mappings describe structures of JavaScript objects
-
-
-* **Strongly-typed**  * Conversion between string content on XML side and values on the JavaScript side is controlled by declared property types.
-
-
-* Provides **extensible type system**  * Supports most XML Schema simple types
+* **Strongly-structured**
+  * XML/object mappings describe structures of JavaScript objects
+* **Strongly-typed**
+  * Conversion between string content on XML side and values on the JavaScript side is controlled by declared property types.
+* Provides **extensible type system**
+  * Supports most XML Schema simple types
   * Supports enumerations, list and union simple types
   * Allows adding own simple types
   * Supports complex types consisting of several properties
   * Supports deriving complex types by extensions
-
-
-* Provides **advanced property system**  * Value, attribute, element, element reference properties for string processing of XML content
+* Provides **advanced property system**
+  * Value, attribute, element, element reference properties for string processing of XML content
   * Any attribute, any element properties for "lax" processing for XML content
-
-
-

--- a/xslt/c2md.xsl
+++ b/xslt/c2md.xsl
@@ -8,7 +8,7 @@
 
   <xsl:output method="text"/>
 
-  <!--xsl:strip-space elements="acxhtml:div acxhtml:table acxhtml:tbody acxhtml:tr acxhtml:ol acxhtml:ul ac:* ri:*"/-->
+  <xsl:strip-space elements="acxhtml:div acxhtml:table acxhtml:tbody acxhtml:tr acxhtml:ol acxhtml:ul ac:* ri:*"/>
 
   <xsl:template match="@*|node()" priority="-1">
     <xsl:copy>
@@ -28,67 +28,69 @@
 
 
   <xsl:template match="acxhtml:h1">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
     <xsl:text># </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:h2">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
     <xsl:text>## </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:h3">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
     <xsl:text>### </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:h4">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
     <xsl:text>#### </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:h5">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
     <xsl:text>##### </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:h6">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
     <xsl:text>###### </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:ul">
+    <xsl:if test="not(ancestor::acxhtml:ul or ancestor::acxhtml:ol)">
+      <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates/>
-    <xsl:text>&#xA;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:ul/acxhtml:li">
+    <xsl:text>&#xa;</xsl:text>
     <xsl:for-each select="../ancestor::*[local-name(.)='ol' or local-name(.)='ul']">
       <xsl:text>  </xsl:text>
     </xsl:for-each>
     <xsl:text>* </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:p">
-    <xsl:apply-templates/>
     <xsl:if test="not(ancestor::acxhtml:td or ancestor::acxhtml:th)">
       <xsl:text>&#xa;</xsl:text>
       <xsl:text>&#xa;</xsl:text>
     </xsl:if>
+    <xsl:apply-templates/>
   </xsl:template>
 
   <xsl:template match="acxhtml:a">
@@ -132,6 +134,8 @@
 
 
   <xsl:template match="ac:structured-macro[@ac:name='code']">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:text>&#xa;</xsl:text>
     <xsl:text>```</xsl:text>
     <xsl:variable name="contents">
       <xsl:apply-templates/>
@@ -144,8 +148,6 @@
       <xsl:text>&#xa;</xsl:text>
     </xsl:if>
     <xsl:text>```</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="ac:structured-macro/ac:parameter"/>
@@ -186,20 +188,20 @@
   </xsl:template>
 
   <xsl:template match="acxhtml:table">
-    <xsl:apply-templates/>
     <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates/>
   </xsl:template>
 
   <xsl:template match="acxhtml:tr[acxhtml:th]">
+    <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates/>
     <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates mode="header-dashes"/>
-    <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 
   <xsl:template match="acxhtml:tr[acxhtml:td]">
-    <xsl:apply-templates/>
     <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates/>
   </xsl:template>
 
   <xsl:template match="acxhtml:th">


### PR DESCRIPTION
- Change the line break generation paradigm to make tags generate line
  breaks before the content instead of after the content. In this way,
  nested lists are correctly converted. Before this change, the line
  break before the first "  *" was missing.
- Update "Features.md" with the new generated result.
- Also: Don't generate whitespace into links.

Bug: Issue #6