### PR TITLE
Render links to other pages with standard link syntax

### DIFF
--- a/samples/Jsonix/Generating-Mappings-from-XML-Schemas.md
+++ b/samples/Jsonix/Generating-Mappings-from-XML-Schemas.md
@@ -14,7 +14,7 @@ java
 
 ## XJC plugin
 
-If you're already using XJC to compile your schemas, you'll just need to use the `jsonix` plugin for XJC. The plugin can be downloaded [[here|Downloads]]. It is activated using the following command-line option:
+If you're already using XJC to compile your schemas, you'll just need to use the `jsonix` plugin for XJC. The plugin can be downloaded [here](Downloads.md). It is activated using the following command-line option:
 
 ```
 -Xjsonix

--- a/samples/Jsonix/Using-Jsonix-in-Your-JavaScript-Program.md
+++ b/samples/Jsonix/Using-Jsonix-in-Your-JavaScript-Program.md
@@ -1,8 +1,8 @@
 # Using Jsonix in your JavaScript program
 
-* [[Download|Downloads]] Jsonix or [install](https://npmjs.org/package/xmldom) it with npm in node.js
+* [Download](Downloads.md) Jsonix or [install](https://npmjs.org/package/xmldom) it with npm in node.js
 * Add/import/include/require Jsonix scripts into your program/page.
-* [[Write|Mapping XML to JavaScript Objects]] or [[generate|Generating mappings from XML Schema]] Jsonix mappings.
+* [Write](Mapping XML to JavaScript Objects.md) or [generate](Generating mappings from XML Schema.md) Jsonix mappings.
 * Create Jsonix context from these mappings.
   * To marshal (serialize JavaScript objects as XML):
     * Create marshaller.

--- a/samples/Jsonix/Working-Example.md
+++ b/samples/Jsonix/Working-Example.md
@@ -300,5 +300,5 @@ java
   purchaseorder.xsd // Schema
 ```
 
-You can [[download|Downloads]] the complete example.
+You can [download](Downloads.md) the complete example.
 

--- a/xslt/c2md.xsl
+++ b/xslt/c2md.xsl
@@ -151,17 +151,18 @@
   <xsl:template match="ac:structured-macro/ac:parameter"/>
 
   <xsl:template match="ac:link[ri:*]">
-    <xsl:text>[[</xsl:text>
+    <xsl:text>[</xsl:text>
     <xsl:if test="ac:link-body or ac:plain-text-link-body">
       <xsl:apply-templates select="ac:link-body | ac:plain-text-link-body"/>
-      <xsl:text>|</xsl:text>
     </xsl:if>
+    <xsl:text>]</xsl:text>
+    <xsl:text>(</xsl:text>
     <xsl:apply-templates select="ri:*" mode="link-target"/>
     <xsl:if test="@ac:anchor">
       <xsl:text>#</xsl:text>
       <xsl:value-of select="translate(lower-case(@ac:anchor), ' ', '-')"/>
     </xsl:if>
-    <xsl:text>]]</xsl:text>
+    <xsl:text>)</xsl:text>
   </xsl:template>
 
   <xsl:template match="ac:link[not(ri:*) and @ac:anchor]">
@@ -182,7 +183,7 @@
   </xsl:template>
 
   <xsl:template match="ri:page[@ri:content-title]" mode="link-target">
-    <xsl:value-of select="@ri:content-title"/>
+    <xsl:value-of select="concat(@ri:content-title, '.md')"/>
   </xsl:template>
 
   <xsl:template match="acxhtml:table">


### PR DESCRIPTION
Instead of using the uncommon wiki-style link syntax `[[name|page]]`, use standard relative links `[name](page.md)`

Updated all affected samples.